### PR TITLE
Fix options extend

### DIFF
--- a/src/schema-form.js
+++ b/src/schema-form.js
@@ -35,7 +35,7 @@ angular.module('mohsen1.schema-form', [])
       }
 
       var formEl = window.document.createElement('div');
-      var options = angular.extend(SchemaForm.options, {schema: scope.schema});
+      var options = angular.extend({}, SchemaForm.options, {schema: scope.schema});
       var jsonEditor = null;
 
       element.prepend(formEl);


### PR DESCRIPTION
Extend SchemaForm.options and schema to new object instead of SchemaForm.options so the default will not be overridden. This fixes the issue with multiple editors.